### PR TITLE
Do not show DeviceID in lists.

### DIFF
--- a/commands/storage/lmi/scripts/storage/cmd/fs.py
+++ b/commands/storage/lmi/scripts/storage/cmd/fs.py
@@ -73,7 +73,7 @@ from lmi.scripts.storage.common import (size2str, get_devices, get_children,
 LOG = get_logger(__name__)
 
 class FSList(command.LmiLister):
-    COLUMNS = ('Device', 'Name', "ElementName", "Type")
+    COLUMNS = ("Name", "ElementName", "Type")
 
     def transform_options(self, options):
         """
@@ -87,11 +87,6 @@ class FSList(command.LmiLister):
         Implementation of 'fs list' command.
         """
         for fmt in fs.get_formats(ns, devices, fs.FORMAT_ALL, _all):
-            device = fmt.first_associator(AssocClass="CIM_ResidesOnExtent")
-            if device:
-                devname = device.DeviceID
-            else:
-                devname = "(none)"
             name = fmt.Name
             label = fmt.ElementName
             if "FileSystemType" in fmt.properties():
@@ -102,7 +97,7 @@ class FSList(command.LmiLister):
                 # it must be LMI_DataFormat
                 fstype = fmt.FormatTypeDescription
             # TODO: add free space when OpenLMI provides it
-            yield (devname, name, label, fstype)
+            yield (name, label, fstype)
 
 
 class FSListSupported(command.LmiLister):

--- a/commands/storage/lmi/scripts/storage/cmd/lv.py
+++ b/commands/storage/lmi/scripts/storage/cmd/lv.py
@@ -76,7 +76,7 @@ from lmi.scripts.storage.common import (size2str, get_devices, get_children,
 LOG = get_logger(__name__)
 
 class LVList(command.LmiLister):
-    COLUMNS = ('DeviceID', "Name", "ElementName", "Size")
+    COLUMNS = ("Name", "Size")
 
     def transform_options(self, options):
         """
@@ -92,10 +92,7 @@ class LVList(command.LmiLister):
         for lv in lvm.get_lvs(ns, vgs):
             size = size2str(lv.NumberOfBlocks * lv.BlockSize,
                     self.app.config.human_friendly)
-            yield (lv.DeviceID,
-                    lv.Name,
-                    lv.ElementName,
-                    size)
+            yield (lv.Name, size)
 
 
 class LVCreate(command.LmiCheckResult):

--- a/commands/storage/lmi/scripts/storage/cmd/partition.py
+++ b/commands/storage/lmi/scripts/storage/cmd/partition.py
@@ -108,7 +108,7 @@ from lmi.scripts.storage.common import (size2str, get_devices, get_children,
 LOG = get_logger(__name__)
 
 class PartitionList(command.LmiLister):
-    COLUMNS = ('DeviceID', "Name", "ElementName", "Type", "Size")
+    COLUMNS = ("Name", "Type", "Size")
 
     def transform_options(self, options):
         """
@@ -135,11 +135,7 @@ class PartitionList(command.LmiLister):
                     ptype = "unknown"
             size = size2str(part.NumberOfBlocks * part.BlockSize,
                     self.app.config.human_friendly)
-            yield (part.DeviceID,
-                    part.Name,
-                    part.ElementName,
-                    ptype,
-                    size)
+            yield (part.Name, ptype, size)
 
 
 class PartitionCreate(command.LmiCheckResult):

--- a/commands/storage/lmi/scripts/storage/cmd/partition_table.py
+++ b/commands/storage/lmi/scripts/storage/cmd/partition_table.py
@@ -81,7 +81,7 @@ from lmi.scripts.storage.common import (size2str, get_devices, get_children,
 LOG = get_logger(__name__)
 
 class PartitionTableList(command.LmiLister):
-    COLUMNS = ('DeviceID', 'Name', 'ElementName', 'Type', 'Largest free region')
+    COLUMNS = ('Name', 'Type', 'Largest free region')
 
     def transform_options(self, options):
         """
@@ -107,12 +107,7 @@ class PartitionTableList(command.LmiLister):
                 table_type = cls.PartitionStyleValues.value_name(
                         table.PartitionStyle)
 
-            yield (device.DeviceID,
-                    device.Name,
-                    device.ElementName,
-                    table_type,
-                    largest_size
-                    )
+            yield (device.Name, table_type, largest_size)
 
 
 class PartitionTableCreate(command.LmiCheckResult):

--- a/commands/storage/lmi/scripts/storage/cmd/raid.py
+++ b/commands/storage/lmi/scripts/storage/cmd/raid.py
@@ -80,7 +80,7 @@ from lmi.scripts.storage.common import (size2str, get_devices, get_children,
 LOG = get_logger(__name__)
 
 class RaidList(command.LmiLister):
-    COLUMNS = ('DeviceID', 'Name', "Level", "Nr. of members")
+    COLUMNS = ('Name', "Level", "Nr. of members")
 
     def execute(self, ns):
         """
@@ -88,7 +88,7 @@ class RaidList(command.LmiLister):
         """
         for r in raid.get_raids(ns):
             members = raid.get_raid_members(ns, r)
-            yield (r.DeviceID, r.ElementName, r.Level, len(members))
+            yield (r.ElementName, r.Level, len(members))
 
 
 class RaidCreate(command.LmiCheckResult):

--- a/commands/storage/lmi/scripts/storage/cmd/vg.py
+++ b/commands/storage/lmi/scripts/storage/cmd/vg.py
@@ -87,8 +87,7 @@ from lmi.scripts.storage.common import (size2str, get_devices, get_children,
 LOG = get_logger(__name__)
 
 class VGList(command.LmiLister):
-    COLUMNS = ('InstanceID', 'ElementName', "ExtentSize", "Total space",
-            "Free space")
+    COLUMNS = ('ElementName', "ExtentSize", "Total space", "Free space")
 
     def execute(self, ns):
         """
@@ -101,8 +100,7 @@ class VGList(command.LmiLister):
                     self.app.config.human_friendly)
             remaining_space = size2str(vg.RemainingManagedSpace,
                     self.app.config.human_friendly)
-            yield (vg.InstanceID,
-                    vg.ElementName,
+            yield (vg.ElementName,
                     extent_size,
                     total_space,
                     remaining_space)

--- a/commands/storage/lmi/scripts/storage/storage_cmd.py
+++ b/commands/storage/lmi/scripts/storage/storage_cmd.py
@@ -146,9 +146,7 @@ def get_device_info(ns, device, human_friendly):
         size = 'N/A'
 
     fslabel = fs.get_device_format_label(ns, device)
-    return (device.DeviceID,
-            device.Name,
-            device.ElementName,
+    return (device.Name,
             size,
             fslabel)
 
@@ -157,9 +155,7 @@ def get_pool_info(_ns, pool, human_friendly):
     Return detailed information of the Volume Group to show.
     """
     size = size2str(pool.TotalManagedSpace, human_friendly)
-    return (pool.InstanceID,
-            pool.ElementName,
-            pool.ElementName,
+    return (pool.ElementName,
             size,
             "volume group (LVM)")
 
@@ -174,7 +170,7 @@ def get_obj_info(ns, obj, human_friendly):
 
 
 class Lister(command.LmiLister):
-    COLUMNS = ('DeviceID', "Name", "ElementName", "Size", "Format")
+    COLUMNS = ("Name", "Size", "Format")
 
     def transform_options(self, options):
         """
@@ -190,15 +186,6 @@ class Lister(command.LmiLister):
         devices = get_devices(ns, devices)
         for dev in devices:
             yield get_device_info(ns, dev, self.app.config.human_friendly)
-
-    def execute(self, ns, devices=None):
-        """
-        Implementation of 'device list' command.
-        """
-        devices = get_devices(ns, devices)
-        for dev in devices:
-            yield get_device_info(ns, dev, self.app.config.human_friendly)
-
 
 class Show(command.LmiLister):
     COLUMNS = ('Name', 'Value')
@@ -226,7 +213,7 @@ class Show(command.LmiLister):
 
 
 class Depends(command.LmiLister):
-    COLUMNS = ('DeviceID', "Name", "ElementName", "Size", "Format")
+    COLUMNS = ("Name", "Size", "Format")
 
     def transform_options(self, options):
         """
@@ -246,7 +233,7 @@ class Depends(command.LmiLister):
 
 
 class Provides(command.LmiLister):
-    COLUMNS = ('DeviceID', "Name", "ElementName", "Size", "Format")
+    COLUMNS = ("Name", "Size", "Format")
 
     def transform_options(self, options):
         """
@@ -266,7 +253,7 @@ class Provides(command.LmiLister):
 
 
 class Tree(command.LmiLister):
-    COLUMNS = ('DeviceID', "Name", "ElementName", "Size", "Format")
+    COLUMNS = ("Name", "Size", "Format")
 
     def prepare_tree_line(self, level, name, subsequent):
         """

--- a/commands/storage/test/lmi/test_deps.sh
+++ b/commands/storage/test/lmi/test_deps.sh
@@ -79,49 +79,49 @@ rlPhaseEnd
 function check_part1()
 {
     prefix=$1
-    rlAssertGrep "$prefix.*\"${LMI_STORAGE_DISK}1\",\"${DISKNAME}1\",\"$PARTSIZE\",\"software RAID\"" $rlRun_LOG
+    rlAssertGrep "\"$prefix${LMI_STORAGE_DISK}1\",\"$PARTSIZE\",\"software RAID\"" $rlRun_LOG
 }
 
 function check_part2()
 {
     prefix=$1
-    rlAssertGrep "$prefix.*\"${LMI_STORAGE_DISK}2\",\"${DISKNAME}2\",\"$PARTSIZE\",\"software RAID\"" $rlRun_LOG
+    rlAssertGrep "\"$prefix${LMI_STORAGE_DISK}2\",\"$PARTSIZE\",\"software RAID\"" $rlRun_LOG
 }
 
 function check_part3()
 {
     prefix=$1
-    rlAssertGrep "$prefix.*\"${LMI_STORAGE_DISK}3\",\"${DISKNAME}3\",\".*\",\"physical volume (LVM)\"" $rlRun_LOG
+    rlAssertGrep "\"$prefix${LMI_STORAGE_DISK}3\",\".*\",\"physical volume (LVM)\"" $rlRun_LOG
 }
 
 function check_md()
 {
     prefix=$1
-    rlAssertGrep "\"$prefix/dev/disk/by-id/md-name-.*:$MDNAME\",\"/dev/md/$MDNAME\",\"$MDNAME\",\".*\",\"physical volume (LVM)\"" $rlRun_LOG
+    rlAssertGrep "\"$prefix/dev/md/$MDNAME\",\".*\",\"physical volume (LVM)\"" $rlRun_LOG
 }
 
 function check_lv1()
 {
     prefix=$1
-    rlAssertGrep "\"$prefix/dev/disk/by-id/dm-name-$VGNAME-${LVNAME}1\",\"/dev/mapper/$VGNAME-${LVNAME}1\",\"${LVNAME}1\",\".*M\",\"xfs\"" $rlRun_LOG
+    rlAssertGrep "\"$prefix/dev/mapper/$VGNAME-${LVNAME}1\",\".*M\",\"xfs\"" $rlRun_LOG
 }
 
 function check_lv2()
 {
     prefix=$1
-    rlAssertGrep "\"$prefix/dev/disk/by-id/dm-name-$VGNAME-${LVNAME}2\",\"/dev/mapper/$VGNAME-${LVNAME}2\",\"${LVNAME}2\",\".*M\",\"ext4\"" $rlRun_LOG
+    rlAssertGrep "\"$prefix/dev/mapper/$VGNAME-${LVNAME}2\",\".*M\",\"ext4\"" $rlRun_LOG
 }
 
 function check_disk()
 {
     prefix=$1
-    rlAssertGrep "$prefix.*\"$LMI_STORAGE_DISK\",\"$DISKNAME\",\".*\",\"GPT partition table\"" $rlRun_LOG
+    rlAssertGrep "\"$prefix$LMI_STORAGE_DISK\".*,\"GPT partition table\"" $rlRun_LOG
 }
 
 function check_vg()
 {
     prefix=$1
-    rlAssertGrep "\"${prefix}LMI:VG:$VGNAME\",\"$VGNAME\",\"$VGNAME\",\".*\",\"volume group (LVM)\"" $rlRun_LOG
+    rlAssertGrep "\"$prefix$VGNAME\",.*,\"volume group (LVM)\"" $rlRun_LOG
 }
 
 rlPhaseStartTest "lmi storage list"

--- a/commands/storage/test/lmi/test_fs.sh
+++ b/commands/storage/test/lmi/test_fs.sh
@@ -52,7 +52,7 @@ rlPhaseStartTest
 
         rlLogInfo "Test fs list"
         # the last column is lower-case filesystem type in double quotes
-        fstype=$(cat $rlRun_LOG | cut -f 4 -d ',' )
+        fstype=$(cat $rlRun_LOG | cut -f 3 -d ',' )
         rlAssertEquals "Checking fs $fsname is present on $part" "\"$fsname\"" $fstype
         rm $rlRun_LOG
 

--- a/commands/storage/test/lmi/test_lvm.sh
+++ b/commands/storage/test/lmi/test_lvm.sh
@@ -69,7 +69,6 @@ rlPhaseStartTest "CreateVG"
 
     rlLogInfo "Check lmi vg list shows it"
     rlRun -s "$LMI -N -H -L csv storage vg list"
-    rlAssertGrep "\"LMI:VG:$VGNAME\"" $rlRun_LOG
     rlAssertGrep "\"$VGNAME\"" $rlRun_LOG
     rm $rlRun_LOG
 
@@ -99,15 +98,13 @@ rlPhaseStartTest "CreateLV"
 
     rlLogInfo "Check lmi lv list shows them"
     rlRun -s "$LMI -N -H -L csv storage lv list $VGNAME"
-    rlAssertGrep "\"/dev/disk/by-id/dm-name-$VGNAME-$LVNAME1\"" $rlRun_LOG
-    rlAssertGrep "\"$LVNAME1\"" $rlRun_LOG
+    rlAssertGrep "\"/dev/mapper/$VGNAME-$LVNAME1\"" $rlRun_LOG
     rlAssertGrep "\"$LVSIZE1\"" $rlRun_LOG
-    rlAssertGrep "\"/dev/disk/by-id/dm-name-$VGNAME-$LVNAME2\"" $rlRun_LOG
-    rlAssertGrep "\"$LVNAME2\"" $rlRun_LOG
+    rlAssertGrep "\"/dev/mapper/$VGNAME-$LVNAME2\"" $rlRun_LOG
     rlAssertGrep "\"$LVSIZE2\"" $rlRun_LOG
     rm $rlRun_LOG
 
-    rlLogInfo "Check lmi lv show shows them"
+    rlLogInfo "Check lmi storage lv show shows them"
     rlRun -s "$LMI -N -H -L csv storage lv show $LVNAME1"
     rlAssertGrep "\"DeviceID\",\"/dev/disk/by-id/dm-name-$VGNAME-$LVNAME1\"" $rlRun_LOG
     rlAssertGrep "\"Name\",\"/dev/mapper/$VGNAME-$LVNAME1\"" $rlRun_LOG
@@ -146,11 +143,9 @@ rlPhaseStartTest "DeleteLV"
 
     rlLogInfo "Check lmi storage lv list doesn't show them"
     rlRun -s "$LMI -N -H -L csv storage lv list $VGNAME"
-    rlAssertNotGrep "\"LMI:/dev/disk/by-id/dm-name-$VGNAME-$LVNAME1\"" $rlRun_LOG
-    rlAssertNotGrep "\"$LVNAME1\"" $rlRun_LOG
+    rlAssertNotGrep "\"/dev/mapper/$VGNAME-$LVNAME1\"" $rlRun_LOG
     rlAssertNotGrep "\"$LVSIZE1\"" $rlRun_LOG
     rlAssertNotGrep "\"LMI:/dev/disk/by-id/dm-name-$VGNAME-$LVNAME2\"" $rlRun_LOG
-    rlAssertNotGrep "\"$LVNAME2\"" $rlRun_LOG
     rlAssertNotGrep "\"$LVSIZE2\"" $rlRun_LOG
     rm $rlRun_LOG
 

--- a/commands/storage/test/lmi/test_partition_gpt.sh
+++ b/commands/storage/test/lmi/test_partition_gpt.sh
@@ -75,9 +75,9 @@ rlPhaseStartTest "Create partitions"
 
     rlLogInfo "Check lmi storage partition list shows them"
     rlRun -s "$LMI -NHL csv storage partition list $LMI_STORAGE_DISK"
-    rlAssertGrep "\"${LMI_STORAGE_DISK}1\",\"${DISKNAME}1\",\"\",\"$SIZE1\"" $rlRun_LOG
-    rlAssertGrep "\"${LMI_STORAGE_DISK}2\",\"${DISKNAME}2\",\"\",\"$SIZE2\"" $rlRun_LOG
-    rlAssertGrep "\"${LMI_STORAGE_DISK}3\",\"${DISKNAME}3\"" $rlRun_LOG
+    rlAssertGrep "\"${LMI_STORAGE_DISK}1\",\"\",\"$SIZE1\"" $rlRun_LOG
+    rlAssertGrep "\"${LMI_STORAGE_DISK}2\",\"\",\"$SIZE2\"" $rlRun_LOG
+    rlAssertGrep "\"${LMI_STORAGE_DISK}3\"," $rlRun_LOG
     rm $rlRun_LOG
 
     rlLogInfo "Check lmi storage partition show shows them"
@@ -106,9 +106,9 @@ rlPhaseStartTest "Delete partitions"
 
     rlLogInfo "Check lmi storage partition list does not show them"
     rlRun -s "$LMI -NHL csv storage partition list $LMI_STORAGE_DISK"
-    rlAssertNotGrep "\"${LMI_STORAGE_DISK}1\",\"${DISKNAME}1\",\"\",\"$SIZE1\"" $rlRun_LOG
-    rlAssertNotGrep "\"${LMI_STORAGE_DISK}2\",\"${DISKNAME}2\",\"\",\"$SIZE2\"" $rlRun_LOG
-    rlAssertNotGrep "\"${LMI_STORAGE_DISK}3\",\"${DISKNAME}3\"" $rlRun_LOG
+    rlAssertNotGrep "\"${LMI_STORAGE_DISK}1\",\"\",\"$SIZE1\"" $rlRun_LOG
+    rlAssertNotGrep "\"${LMI_STORAGE_DISK}2\",\"\",\"$SIZE2\"" $rlRun_LOG
+    rlAssertNotGrep "\"${LMI_STORAGE_DISK}3\"," $rlRun_LOG
     rm $rlRun_LOG
 rlPhaseEnd
 

--- a/commands/storage/test/lmi/test_partition_msdos.sh
+++ b/commands/storage/test/lmi/test_partition_msdos.sh
@@ -78,10 +78,10 @@ rlPhaseStartTest "Create partitions"
     rlRun "$LMI -NHL csv storage partition list"
     rlRun "$LMI -NHL csv storage partition list ${LMI_STORAGE_DISK}2"
     rlRun -s "$LMI -NHL csv storage partition list $LMI_STORAGE_DISK"
-    rlAssertGrep "\"${LMI_STORAGE_DISK}1\",\"${DISKNAME}1\",\"primary\",\"$SIZE1\"" $rlRun_LOG
-    rlAssertGrep "\"${LMI_STORAGE_DISK}2\",\"${DISKNAME}2\",\"extended\"," $rlRun_LOG
-    rlAssertGrep "\"${LMI_STORAGE_DISK}5\",\"${DISKNAME}5\",\"logical\",\"$SIZE2\"" $rlRun_LOG
-    rlAssertGrep "\"${LMI_STORAGE_DISK}6\",\"${DISKNAME}6\",\"logical\"," $rlRun_LOG
+    rlAssertGrep "\"${LMI_STORAGE_DISK}1\",\"primary\",\"$SIZE1\"" $rlRun_LOG
+    rlAssertGrep "\"${LMI_STORAGE_DISK}2\",\"extended\"," $rlRun_LOG
+    rlAssertGrep "\"${LMI_STORAGE_DISK}5\",\"logical\",\"$SIZE2\"" $rlRun_LOG
+    rlAssertGrep "\"${LMI_STORAGE_DISK}6\",\"logical\"," $rlRun_LOG
     rm $rlRun_LOG
 
     rlLogInfo "Check lmi partition show shows them"
@@ -119,9 +119,9 @@ rlPhaseStartTest "Delete partitions"
 
     rlLogInfo "Check lmi storage partition list does not show them"
     rlRun -s "$LMI -NHL csv storage partition list $LMI_STORAGE_DISK"
-    rlAssertNotGrep "\"${LMI_STORAGE_DISK}1\",\"${DISKNAME}1\",\"\",\"$SIZE1\"" $rlRun_LOG
-    rlAssertNotGrep "\"${LMI_STORAGE_DISK}2\",\"${DISKNAME}2\"" $rlRun_LOG
-    rlAssertNotGrep "\"${LMI_STORAGE_DISK}5\",\"${DISKNAME}5\"" $rlRun_LOG
+    rlAssertNotGrep "\"${LMI_STORAGE_DISK}1\"" $rlRun_LOG
+    rlAssertNotGrep "\"${LMI_STORAGE_DISK}2\"" $rlRun_LOG
+    rlAssertNotGrep "\"${LMI_STORAGE_DISK}5\"" $rlRun_LOG
     rm $rlRun_LOG
 rlPhaseEnd
 

--- a/commands/storage/test/lmi/test_raid.sh
+++ b/commands/storage/test/lmi/test_raid.sh
@@ -62,7 +62,6 @@ function test_raid() {
         rlLogInfo "Check lmi storage raid list output"
         rlRun -s "$LMI -NHL csv storage raid list"
         rlAssertGrep "\"$name\"" $rlRun_LOG
-        rlAssertGrep "\"/dev/disk/by-id/md-name-.*:$name\"" $rlRun_LOG
         member_count=$(echo $parts | wc -w)
         rlAssertGrep ",$level,$member_count\$" $rlRun_LOG
         rm $rlRun_LOG
@@ -89,8 +88,7 @@ function test_raid() {
 
         rlLogInfo "Check lmi storage raid list output"
         rlRun -s "$LMI -NHL csv storage raid list"
-        rlAssertNotGrep "\"$name\"" $rlRun_LOG
-        rlAssertNotGrep "\"/dev/disk/by-id/md-name-.*:$name\"" $rlRun_LOG
+        rlAssertNotGrep "\"/dev/md/$name\"" $rlRun_LOG
         rm $rlRun_LOG
 
         rlLogInfo "Check lmi storage raid show output"


### PR DESCRIPTION
DeviceID is internal OpenLMI ID to identify block devices. It's quite long
and most admins will use '/dev/sda' (or just 'sda') anyway, so let's remove
it from all 'list' commands output.

'show' command will show it, if anybody is interested.
