### PR TITLE
networking: prefix length of route should be int

### DIFF
--- a/commands/networking/lmi/scripts/networking/__init__.py
+++ b/commands/networking/lmi/scripts/networking/__init__.py
@@ -551,7 +551,7 @@ def add_static_route(ns, setting, address, prefix, metric=None, next_hop=None):
         result = setting.LMI_AddStaticIPRoute(
                 AddressType=setting.LMI_AddStaticIPRoute.AddressTypeValues.IPv6,
                 DestinationAddress=address,
-                PrefixLength=str(prefix))
+                PrefixLength=prefix)
     else:
         raise LmiInvalidOptions("Invalid IP address: %s" % address)
     if result.rval != 0:


### PR DESCRIPTION
PrefixLength parameter of static IP route was incorrectly converted to
string when it should be integer. New lmishell can convert it to propert
type. This commit fixes it even for older lmishell.
