### PR TITLE
Fixed 'lmi mount create' command.

### DIFF
--- a/commands/storage/lmi/scripts/storage/cmd/mount.py
+++ b/commands/storage/lmi/scripts/storage/cmd/mount.py
@@ -192,14 +192,6 @@ class MountShow(command.LmiLister):
 class MountCreate(command.LmiCheckResult):
     EXPECT = None
 
-    def transform_options(self, options):
-        """
-        There is only one <device> option, but docopt passes it as array
-        (because in other commands it is used with '...'). So let's
-        transform it to scalar.
-        """
-        options['<device>'] = options.pop('<device>')[0]
-
     def execute(self, ns, device, mountpoint, fs_type=None, options=None):
         """
         Implementation of 'mount create' command.


### PR DESCRIPTION
It does _not_ accept list of devices.
