### PR TITLE
Added missing import.

### DIFF
--- a/commands/account/lmi/scripts/account/__init__.py
+++ b/commands/account/lmi/scripts/account/__init__.py
@@ -39,6 +39,7 @@ a remote managed system.
 
 from lmi.scripts.common.errors import LmiFailed
 from lmi.shell.LMIInstanceName import LMIInstanceName
+from lmi.shell.LMIInstance import LMIInstance
 from lmi.scripts.common import get_logger
 import pywbem
 import lmi.scripts.common


### PR DESCRIPTION
This fixes traceback in delete_group() function which uses it:
    error   : global name 'LMIInstance' is not defined
